### PR TITLE
Fixes #7 Set $ENV:Temp for MacOS & Linux

### DIFF
--- a/Dual Account Script/DualAccount-Creation.ps1
+++ b/Dual Account Script/DualAccount-Creation.ps1
@@ -1079,7 +1079,15 @@ function Export-Platform
 {
     param ($platformID)
 
-    $exportPath = "$( Join-Path -Path $ENV:Temp -ChildPath $platformID ).zip"
+    # Ensure Temp is set
+    if (-not $ENV:Temp -or -not (Test-Path $ENV:Temp)) {
+        $ENV:Temp = "/tmp"
+        Write-LogMessage -Type Info -Msg "Environment variable 'Temp' was not set. Defaulting to '/tmp'."
+    }
+
+    # Construct export path
+    $exportPath = "$(Join-Path -Path $ENV:Temp -ChildPath $platformID).zip"
+    Write-LogMessage -Type Debug -Msg "Export Path: $exportPath"
 
     $creds = New-Object -TypeName System.Management.Automation.PSCredential($global:ParamsObj.PASUserName, $global:ParamsObj.PASPassword)
 


### PR DESCRIPTION
### Desired Outcome

Fix issues on MacOS and Linux with the usage of the $ENV:Temp variable.

### Implemented Changes

Changes were made to the `Export-Platform` module to include a conditional check on the environment variable `TEMP`, and if unset is set to the default `/tmp`.  Assumption can be made that no set `TEMP` would only be on Linux or MacOS. Also, added log messages to reflect conditions detected.

### Connected Issue/Story

Resolves #7 

CyberArk internal issue ID: n/a

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
